### PR TITLE
Fix handling of mining.subscribe reply and extranonce2_size

### DIFF
--- a/pyminer.py
+++ b/pyminer.py
@@ -355,14 +355,20 @@ class Miner(SimpleJsonRpcClient):
 
         (tmp, extranonce1, extranonce2_size) = reply['result']
 
-        if not isinstance(tmp, list) or len(tmp) != 1 or not isinstance(tmp[0], list) or not len(tmp[0]) == 2:
+        if not isinstance(tmp, list) or len(tmp) < 1 or not isinstance(tmp[0], list) or not len(tmp[0]) == 2:
           raise self.MinerWarning('Reply to mining.subscribe is malformed', reply, request)
 
-        (mining_notify, subscription_id) = tmp[0]
+        notify_subscription_id = None
+        for subscription in tmp:
+          if subscription[0] == "mining.notify":
+            notify_subscription_id = subscription[1]
 
-        self._subscription.set_subscription(subscription_id, extranonce1, extranonce2_size)
+        if notify_subscription_id == None:
+          raise self.MinerWarning('Reply to mining.subscribe is malformed', reply, request)
 
-        logging.debug('Subscribed: subscription_id=%s' % subscription_id)
+        self._subscription.set_subscription(notify_subscription_id, extranonce1, extranonce2_size)
+
+        logging.debug('Subscribed: subscription_id=%s' % notify_subscription_id)
 
         # Request authentication
         self.send(method = 'mining.authorize', params = [ self.username, self.password ])

--- a/shared/shared.py
+++ b/shared/shared.py
@@ -109,8 +109,17 @@ class Job:
         extranonce2 = random.randint(0, 2**31-1)
         self.set_extranonce2(extranonce2)
 
+    def _limit_extranonce2(self, extranonce2):
+        # Convert extranonce2 to hex
+        hex_extranonce2 = int_to_hex32(extranonce2)
+
+        # Ensure the hex string length is twice extranonce2_size
+        hex_extranonce2 = hex_extranonce2[:2 * self._extranonce2_size].zfill(2 * self._extranonce2_size)
+
+        return hex_extranonce2
+
     def set_extranonce2(self, extranonce2):
-        self._extranonce2 = int_to_hex32(extranonce2)
+        self._extranonce2 = self._limit_extranonce2(extranonce2)
 
         coinbase_bin = binascii.unhexlify(self._coinb1) + binascii.unhexlify(self._extranonce1) + binascii.unhexlify(self._extranonce2) + binascii.unhexlify(self._coinb2)
         coinbase_hash_bin = sha256d(coinbase_bin)


### PR DESCRIPTION
Two errors prevented the miner from working on braiins pool. The first is that the code was assuming the mining.notify subscription is the first in the list which isn't always true. The second is that the extranonce2 is the coinbase was not being limited by the size defined in the subscription reply.