### PR TITLE
I2C addon

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -52,5 +52,5 @@ influx:
   timezone: Europe/Berlin
 
 
-i2c:
+i2c_display:
   enabled: false

--- a/config.yml.example
+++ b/config.yml.example
@@ -50,3 +50,7 @@ influx:
   org: piaxe
   bucket: piaxe
   timezone: Europe/Berlin
+
+
+i2c:
+  enabled: false

--- a/piaxe/miner.py
+++ b/piaxe/miner.py
@@ -37,7 +37,11 @@ from shared import shared
 from . import bm1366
 from . import influx
 from . import discord
-from .ssd1306 import SSD1306
+
+try:
+    from .ssd1306 import SSD1306
+except:
+    pass
 
 class Job(shared.Job):
     def __init__(
@@ -489,7 +493,7 @@ class BM1366Miner:
             else:
                 raise Exception(f"unknown alerter: {alerter_config['type']}")
 
-        i2c_config = self.config.get("i2c", None)
+        i2c_config = self.config.get("i2c_display", None)
         if i2c_config is not None and i2c_config.get("enabled", False):
             self.display_thread = threading.Thread(target=self._display_update)
             self.display_thread.start()

--- a/piaxe/miner.py
+++ b/piaxe/miner.py
@@ -515,6 +515,12 @@ class BM1366Miner:
         self.alerter.alert("MINER", "shutdown")
         logging.info("Alerter thread ended ...")
 
+    def _display_update(self):
+        logging.info("display update ...")
+        while not self.stop_event.is_set():
+                self.display.update()
+                time.sleep(2)
+        logging.info("display update ended ...")
 
     def _led_thread(self):
         logging.info("LED thread started ...")
@@ -561,13 +567,6 @@ class BM1366Miner:
                 os._exit(1)
 
             time.sleep(1.5)
-
-    def _display_update(self):
-        logging.info("display update ...")
-        while not self.stop_event.is_set():
-                self.display.update()
-                time.sleep(2)
-        logging.info("display update ended ...")
 
     def _serial_tx_func(self, data):
         with self.serial_lock:

--- a/piaxe/miner.py
+++ b/piaxe/miner.py
@@ -397,6 +397,7 @@ class BM1366Miner:
 
         self.shares = list()
         self.stats = influx.Stats()
+
         self.display = SSD1306(self.stats)
 
         self.miner = self.config['miner']
@@ -521,6 +522,7 @@ class BM1366Miner:
 
     def _display_update(self):
         logging.info("display update ...")
+        self.display.init()
         while not self.stop_event.is_set():
                 self.display.update()
                 time.sleep(2)

--- a/piaxe/ssd1306.py
+++ b/piaxe/ssd1306.py
@@ -1,0 +1,27 @@
+import Adafruit_SSD1306
+from PIL import Image, ImageDraw, ImageFont
+
+RST = None
+
+class SSD1306: 
+    def __init__(self,stats):
+        self.stats = stats
+        self.disp = Adafruit_SSD1306.SSD1306_128_32(rst=RST)
+        self.disp.begin()
+        self.disp.clear()
+        self.disp.display()
+        self.width = self.disp.width
+        self.height = self.disp.height
+        self.image = Image.new('1', (self.width, self.height))
+        self.draw = ImageDraw.Draw(self.image)
+        self.font = ImageFont.load_default()
+
+    def update(self):
+        self.draw.rectangle((0, 0, self.width, self.height), outline=0, fill=0)
+        # Format temperature and hash rate with two decimal places
+        formatted_temp = "{:.2f}".format(self.stats.temp)
+        formatted_hash_rate = "{:.2f}".format(self.stats.hashing_speed)
+        self.draw.text((0, 0), "Temp: " + formatted_temp, font=self.font, fill=255)
+        self.draw.text((0, 10), "HR: " + formatted_hash_rate + " GH", font=self.font, fill=255)
+        self.disp.image(self.image)
+        self.disp.display()

--- a/piaxe/ssd1306.py
+++ b/piaxe/ssd1306.py
@@ -6,6 +6,8 @@ RST = None
 class SSD1306: 
     def __init__(self,stats):
         self.stats = stats
+
+    def init(self):
         self.disp = Adafruit_SSD1306.SSD1306_128_32(rst=RST)
         self.disp.begin()
         self.disp.clear()
@@ -15,9 +17,9 @@ class SSD1306:
         self.image = Image.new('1', (self.width, self.height))
         self.draw = ImageDraw.Draw(self.image)
         self.font = ImageFont.load_default()
+        self.draw.rectangle((0, 0, self.width, self.height), outline=0, fill=0)
 
     def update(self):
-        self.draw.rectangle((0, 0, self.width, self.height), outline=0, fill=0)
         # Format temperature and hash rate with two decimal places
         formatted_temp = "{:.2f}".format(self.stats.temp)
         formatted_hash_rate = "{:.2f}".format(self.stats.hashing_speed)


### PR DESCRIPTION
Added I2C Diaplay functionallity it requires the pip library for Adafruit_SSD1306

config.yml does have it's own config section now for the I2C enable or disable.

used the usual I2C connections of the raspberry pi