### PR TITLE
Update hashrate calulation to use fixed chip difficulty.

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -9,6 +9,7 @@ piaxe:
   name: PiAxe
   chips: 1
   asic_frequency: 485
+  chip_difficulty: 1024
   sdn_pin: 11
   pgood_pin: 13
   nrst_pin: 15
@@ -23,6 +24,7 @@ bitcrane:
   name: BitCrane
   chips: 1000
   asic_frequency: 300
+  chip_difficulty: 1024
   extranonce2_interval: 1.5
   fan_speed: 0.25
 
@@ -32,6 +34,7 @@ qaxe:
   fan_speed_1: 1.0
   fan_speed_2: 1.0
   asic_frequency: 485
+  chip_difficulty: 1024
   extranonce2_interval: 1.9
   serial_port_asic: "/dev/ttyACM0"
   serial_port_ctrl: "/dev/ttyACM1"
@@ -42,6 +45,7 @@ qaxe+:
   fan_speed_1: 1.0
   fan_speed_2: 1.0
   asic_frequency: 490
+  chip_difficulty: 1024
   extranonce2_interval: 1.5
   serial_port_asic: "/dev/ttyACM0"
   serial_port_ctrl: "/dev/ttyACM1"
@@ -51,6 +55,7 @@ flex4axe:
   chips: 16
   fan_speed_1: 1.0
   asic_frequency: 480
+  chip_difficulty: 1024
   extranonce2_interval: 1.9
   serial_port_asic: "/dev/ttyACM0"
   serial_port_ctrl: "/dev/ttyACM1"
@@ -60,6 +65,7 @@ flex4axe:
   chips: 16
   fan_speed_1: 1.0
   asic_frequency: 480
+  chip_difficulty: 1024
   extranonce2_interval: 1.9
   serial_port_asic: "/dev/ttyACM0"
   serial_port_ctrl: "/dev/ttyACM1"

--- a/piaxe/boards/bitcrane.py
+++ b/piaxe/boards/bitcrane.py
@@ -38,6 +38,7 @@ class BitcraneHardware(board.Board):
                                                             timeout=1)
 
         self.set_fan_speed(0, config['fan_speed'])
+        self.chip_difficulty = self.config['chip_difficulty']
 
     def set_fan_speed(self, channel, percent):
         pwm_value = int(255 * percent)

--- a/piaxe/boards/piaxe.py
+++ b/piaxe/boards/piaxe.py
@@ -24,6 +24,7 @@ class RPiHardware(board.Board):
         self.nrst_pin = self.config['nrst_pin']
         self.led_pin = self.config['led_pin']
         self.lm75_address = self.config['lm75_address']
+        self.chip_difficulty = self.config['chip_difficulty']
 
         # Initialize GPIO Pins
         GPIO.setup(self.sdn_pin, GPIO.OUT, initial=GPIO.LOW)

--- a/piaxe/boards/qaxe.py
+++ b/piaxe/boards/qaxe.py
@@ -19,6 +19,7 @@ class QaxeHardware(board.Board):
         self.state_power = 0;
         self.pwm1 = self.config.get('fan_speed_1', 100)
         self.pwm2 = self.config.get('fan_speed_2', 0)
+        self.chip_difficulty = self.config['chip_difficulty']
 
         self.reqid = 0
         self.serial_port_ctrl_lock = threading.Lock()

--- a/piaxe/miner.py
+++ b/piaxe/miner.py
@@ -392,12 +392,14 @@ class BM1366Miner:
         current_time = time.time()
         total_work = 0
 
+        chip_difficulty = self.hardware.chip_difficulty
+
         #min_timestamp = current_time
         #max_timestamp = 0
-        for shares, difficulty, timestamp in self.shares:
+        for shares, timestamp in self.shares:
             # Consider shares only in the last 10 minutes
             if current_time - timestamp <= time_period:
-                total_work += shares * (difficulty << 32)
+                total_work += shares * (chip_difficulty << 32)
                 #min_timestamp = min(min_timestamp, timestamp)
                 #max_timestamp = max(max_timestamp, timestamp)
 
@@ -425,7 +427,7 @@ class BM1366Miner:
 
         self._difficulty = difficulty
         self._set_target(shared.calculate_target(difficulty))
-        self.asics.set_job_difficulty_mask(difficulty)
+        #self.asics.set_job_difficulty_mask(difficulty)
 
         with self.stats.lock:
             self.stats.difficulty = difficulty
@@ -493,6 +495,8 @@ class BM1366Miner:
                     job = saved_job['job']
                     work = saved_job['work']
                     difficulty = saved_job['difficulty']
+
+                    chip_difficulty = self.hardware.chip_difficulty
 
                     if result_job_id != work.id:
                         logging.error("mismatch ids")
@@ -562,13 +566,16 @@ class BM1366Miner:
                         self.stats.valid_shares += 1 if is_valid else 0
 
                         # don't add to shares if it's invalid or it's a duplicate
-                        if is_valid and not duplicate:
-                            self.shares.append((1, difficulty, time.time()))
+                        #if is_valid and not duplicate:
+                        self.shares.append((1, time.time()))
 
                         self.stats.hashing_speed = self.hash_rate()
                         hash_difficulty = shared.calculate_difficulty_from_hash(hash)
                         self.stats.best_difficulty = max(self.stats.best_difficulty, hash_difficulty)
                         self.stats.total_best_difficulty = max(self.stats.total_best_difficulty, hash_difficulty)
+
+                        #debug the hash difficulty
+                        logging.debug("hash difficulty: %d of %d", hash_difficulty, difficulty)
 
                     # restart miner with new extranonce2
                     #self.new_job_event.set() TODO
@@ -579,7 +586,7 @@ class BM1366Miner:
                     # if its invalid it would be rejected
                     # we don't try it but we can count it to not_accepted
                     self.not_accepted_callback()
-                    logging.error("invalid result!")
+                    # logging.error("invalid result!")
                     continue
 
 

--- a/piaxe/miner.py
+++ b/piaxe/miner.py
@@ -392,8 +392,6 @@ class BM1366Miner:
         current_time = time.time()
         total_work = 0
 
-        chip_difficulty = self.hardware.chip_difficulty
-
         #min_timestamp = current_time
         #max_timestamp = 0
         for shares, timestamp in self.shares:
@@ -565,8 +563,6 @@ class BM1366Miner:
                         self.stats.invalid_shares += 1 if not is_valid else 0
                         self.stats.valid_shares += 1 if is_valid else 0
 
-                        # don't add to shares if it's invalid or it's a duplicate
-                        #if is_valid and not duplicate:
                         self.shares.append((1, time.time()))
 
                         self.stats.hashing_speed = self.hash_rate()


### PR DESCRIPTION
Changed miner.py to use a fixed chip difficulty (set in config.yml) to calculate the hashrate. Don't update the chip difficulty when the pool difficulty changes.

chip_difficulty default values will need to be tuned for each miner to generate a response every second or so.